### PR TITLE
Dėl Seimo narių skaičiaus 141->121

### DIFF
--- a/05 Seimas.md
+++ b/05 Seimas.md
@@ -6,7 +6,7 @@
 
 #### 55 straipsnis
 
-Seimą sudaro Tautos atstovai – 141 Seimo narys, kurie renkami ketveriems metams remiantis visuotine, lygia, tiesiogine rinkimų teise ir slaptu balsavimu.
+Seimą sudaro Tautos atstovai – 121 Seimo narys, kurie renkami ketveriems metams remiantis visuotine, lygia, tiesiogine rinkimų teise ir slaptu balsavimu.
 
 Seimas laikomas išrinktu, kai yra išrinkta ne mažiau kaip 3/5 Seimo narių.
 


### PR DESCRIPTION
Lietuvos Respublikos Konstitucijos 55 straipsnio pakeitimo įstatymas

Priėmė: Piliečių referendumas
Šis įstatymas taikomas eiliniams ir pirmalaikiams Lietuvos Respublikos Seimo rinkimams, organizuojamiems po šio įstatymo įsigaliojimo